### PR TITLE
docs: improve instant-runoff docs

### DIFF
--- a/src/irv.rs
+++ b/src/irv.rs
@@ -1,13 +1,17 @@
-use super::Numeric;
-use super::RankedWinners;
-use crate::Transfer;
-use crate::VoteTree;
-use hashbrown::HashSet;
-use num_traits::cast::NumCast;
-use num_traits::Num;
+//! An Instant-Runoff Voting implementation.
+//!
+//! This module contains the implementation for instant-runoff voting, which is sometimes called
+//! ranked choice voting. More information about this voting method can be found at
+//! <https://en.wikipedia.org/wiki/Instant-runoff_voting>.
+
 use std::cmp::Ord;
 use std::hash::Hash;
 use std::ops::AddAssign;
+
+use hashbrown::HashSet;
+use num_traits::{cast::NumCast, Num};
+
+use crate::{Numeric, RankedWinners, Transfer, VoteTree};
 
 #[derive(Debug)]
 struct WeightedVote<T, C>
@@ -19,8 +23,13 @@ where
     remaining: Vec<T>,
 }
 
+/// A default [`Tally`] struct, using [`u64`] as the vote count type.
 pub type DefaultTally<T> = Tally<T, u64>;
 
+/// A custom [`Tally`] struct for instant runoff voting with the option to change vote count types.
+///
+/// If your votes can be counted using the [`u64`] type, then the [`DefaultTally`] type may be of
+/// use to you.
 pub struct Tally<T, C>
 where
     T: Eq + Clone + Hash,                                       // Candidate
@@ -35,35 +44,124 @@ where
     T: Eq + Clone + Hash,                                             // Candidate
     C: Copy + PartialOrd + Ord + AddAssign + Num + NumCast + Numeric, // vote count type
 {
+    /// Creates a new [`Tally`] instance using a given vote [`Transfer`] method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tallystick::{irv::Tally, Transfer};
+    ///
+    /// let tally: Tally<i32, u64> = Tally::new(Transfer::Meek);
+    /// ```
     pub fn new(transfer: Transfer) -> Self {
         Tally {
             running_total: VoteTree::new(),
-            transfer: transfer,
+            transfer,
         }
     }
 
-    /// Create a new `irv::Tally` with the provided candidates
+    /// Creates a new [`Tally`] instance with a predefined set of candidates.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tallystick::{irv::Tally, Transfer};
+    ///
+    /// let candidates = vec![3, 1, 2, 4];
+    /// let tally: Tally<i32, u64> = Tally::with_candidates(Transfer::Meek, candidates);
+    /// ```
     pub fn with_candidates(transfer: Transfer, candidates: Vec<T>) -> Self {
         Tally {
             running_total: VoteTree::with_candidates(candidates),
-            transfer: transfer,
+            transfer,
         }
     }
 
+    /// Adds votes to the tally from a [`Vec`], weighting them by the given value. This can be used
+    /// to allow some ballots/votes to count more or less than others.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tallystick::{irv::Tally, Transfer};
+    ///
+    /// let mut tally: Tally<i32, u64> = Tally::new(Transfer::Meek);
+    /// let votes = vec![3, 1, 2, 4];
+    ///
+    /// tally.add_weighted(votes, 3);
+    /// ```
     pub fn add_weighted(&mut self, selection: Vec<T>, weight: C) {
         self.running_total.add(&selection, weight);
     }
 
+    /// Adds votes to the tally from a [`Vec`], consuming it in the process.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tallystick::{irv::Tally, Transfer};
+    ///
+    /// let mut tally: Tally<i32, u64> = Tally::new(Transfer::Meek);
+    /// let votes = vec![3, 1, 2, 4];
+    ///
+    /// tally.add(votes);
+    /// ```
     pub fn add(&mut self, selection: Vec<T>) {
         // TODO: split add and add_ref in VoteTree
         self.running_total.add(&selection, C::one());
     }
 
+    /// Adds votes to the tally from a [`slice`]. As a [`Vec`] can be dereference into a [`slice`],
+    /// this allows votes to be added without consuming the [`Vec`] unlike [`Tally::add`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tallystick::{irv::Tally, Transfer};
+    ///
+    /// let mut tally: Tally<i32, u64> = Tally::new(Transfer::Meek);
+    /// let votes = vec![3, 1, 2, 4];
+    ///
+    /// tally.add_ref(&votes);
+    /// ```
     pub fn add_ref(&mut self, selection: &[T]) {
         // TODO: split add and add_ref in VoteTree
         self.running_total.add(selection, C::one());
     }
 
+    /// Calculates the current state of the votes and produces a ranked list of candidates.
+    ///
+    /// Each candidate that has been voted for is contained within the returned [`Vec`], alongside
+    /// a ranking stating where they currently stand in the totals. If two candidates are even with
+    /// each other, they will have the same rank. The [`Vec`] will be sorted based on the ranking
+    /// of each candidate in ascending order, with lower ranking implying more votes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tallystick::{irv::Tally, Transfer};
+    ///
+    /// let mut tally: Tally<i32, u64> = Tally::new(Transfer::Meek);
+    /// let ballots = vec![
+    ///     vec![3, 1, 2],
+    ///     vec![3, 2],
+    ///     vec![2, 3],
+    ///     vec![3, 1, 2],
+    /// ];
+    ///
+    /// for ballot in ballots {
+    ///     tally.add_ref(&ballot);
+    /// }
+    ///
+    /// let ranked = tally.tally_ranked();
+    /// let expected = vec![
+    ///     (3, 0),
+    ///     (2, 1),
+    ///     (1, 2),
+    /// ];
+    ///
+    /// assert_eq!(ranked, expected);
+    /// ```
     pub fn tally_ranked(&self) -> Vec<(T, usize)> {
         let max = C::max_value();
 
@@ -139,6 +237,27 @@ where
         ranked
     }
 
+    /// Wraps the result of [`Tally::tally_ranked`] in a [`RankedWinners`] with 1 winner.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tallystick::{RankedWinners, irv::Tally, Transfer};
+    ///
+    /// let mut tally: Tally<i32, u64> = Tally::new(Transfer::Meek);
+    /// let ballots = vec![
+    ///     vec![3, 1, 2, 4],
+    /// ];
+    ///
+    /// for ballot in ballots {
+    ///     tally.add_ref(&ballot);
+    /// }
+    ///
+    /// let winners = tally.tally_winners();
+    /// let ranked_winners = RankedWinners::from((vec![(3, 2)], 1));
+    ///
+    /// assert_eq!(winners, ranked_winners);
+    /// ```
     pub fn tally_winners(&self) -> RankedWinners<T> {
         RankedWinners::from_ranked(self.tally_ranked(), 1)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,10 +100,8 @@ pub mod schulze;
 #[cfg(feature = "nightly")]
 pub mod borda;
 
-/// WORK IN PROGRESS
 #[cfg(feature = "nightly")]
 #[allow(dead_code)]
-#[allow(missing_docs)]
 pub mod irv;
 
 // Common Data Structures

--- a/src/schulze.rs
+++ b/src/schulze.rs
@@ -200,7 +200,7 @@ where
     /// This is a well-known problem in graph theory sometimes called the widest path problem.
     /// This function uses a variant of the Floyd–Warshall algorithm.
     ///
-    /// See: [https://en.wikipedia.org/wiki/Schulze_method#Implementations](https://en.wikipedia.org/wiki/Schulze_method#Implementations)
+    /// See: <https://en.wikipedia.org/wiki/Schulze_method#Implementations>
     pub fn strongest_paths(&self) -> Vec<((T, T), C)> {
         let zero = C::zero();
         let mut p = HashMap::<(usize, usize), C>::new();

--- a/src/votetree.rs
+++ b/src/votetree.rs
@@ -1,6 +1,6 @@
 //! VoteTree data structure for storing transferable preferential votes
-//! This data structure is taken from https://gitlab.com/mbq/wybr,
-//! with a special thanks to mbq.
+//!
+//! This data structure is taken from <https://gitlab.com/mbq/wybr>, with a special thanks to mbq.
 
 use super::Numeric;
 use hashbrown::HashMap;


### PR DESCRIPTION
Improve the instant-runoff docs by adding examples for each method as
documentation tests. Fix some warnings that `cargo doc` produced
relating to invalid or unnecessarily formatted links.